### PR TITLE
docs: update links in error messages for repositoryUrl configuration

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -33,7 +33,7 @@ export function ENOREPOURL() {
   return {
     message: "The `repositoryUrl` option is required.",
     details: `The [repositoryUrl option](${linkify(
-      "docs/usage/configuration.md#repositoryurl"
+      "usage/configuration#repositoryurl"
     )}) cannot be determined from the semantic-release configuration, the \`package.json\` nor the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes).
 
 Please make sure to add the \`repositoryUrl\` to the [semantic-release configuration](${linkify(
@@ -48,7 +48,7 @@ export function EGITNOPERMISSION({ options: { repositoryUrl }, branch: { name } 
     details: `**semantic-release** cannot push the version tag to the branch \`${name}\` on the remote Git repository with URL \`${repositoryUrl}\`.
 
 This can be caused by:
- - a misconfiguration of the [repositoryUrl](${linkify("docs/usage/configuration.md#repositoryurl")}) option
+ - a misconfiguration of the [repositoryUrl](${linkify("usage/configuration#repositoryurl")}) option
  - the repository being unavailable
  - or missing push permission for the user configured via the [Git credentials on your CI environment](${linkify(
    "usage/ci-configuration#authentication"


### PR DESCRIPTION
This pull request updates documentation links in error messages to point to the correct locations in the documentation. The changes ensure that users are directed to the right sections for configuration guidance.

Documentation updates:

* Updated the `repositoryUrl` option link in the `ENOREPOURL` error message to point to `usage/configuration#repositoryurl` instead of `docs/usage/configuration.md#repositoryurl`.
* Updated the `repositoryUrl` option link in the `EGITNOPERMISSION` error message to point to `usage/configuration#repositoryurl` instead of `docs/usage/configuration.md#repositoryurl`.