### PR TITLE
docs: highlight CI Git environment configuration instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ const result = await semanticRelease({
 });
 ```
 
+If you compose `@semantic-release/core` for a real CI publishing workflow, you must configure the Git process environment before calling core. This applies to any composed caller, including both config-driven and direct composition. `@semantic-release/core` does not inject wrapper-level Git defaults for composed callers.
+
+Typical CI setup:
+
+```js
+Object.assign(env, {
+  GIT_AUTHOR_NAME: "semantic-release-bot",
+  GIT_AUTHOR_EMAIL: "semantic-release-bot@example.com",
+  GIT_COMMITTER_NAME: "semantic-release-bot",
+  GIT_COMMITTER_EMAIL: "semantic-release-bot@example.com",
+  ...env,
+  GIT_ASKPASS: "echo",
+  GIT_TERMINAL_PROMPT: 0,
+});
+```
+
+Without this, publishing runs that need to create Git tags, notes, or release commits can fail when Git requires author identity or tries to prompt for credentials in a non-interactive environment.
+
 ### 2. Direct composition
 
 Pass an explicit plugin list or plugin pipeline directly to core when you want the plugin source to be authoritative in your code.
@@ -194,6 +212,8 @@ const result = await semanticRelease({
   plugins: ["@semantic-release/commit-analyzer"],
 });
 ```
+
+As with config-driven composition, direct-composition callers publishing from CI are responsible for configuring the Git process environment before invoking core.
 
 In the direct-composition path, the plugin list passed to core is the plugin source. `options.plugins` from config or shareable-config `extends` is not used as a fallback source for plugin loading.
 
@@ -241,6 +261,7 @@ Examples:
 - Wrapper packages can layer default plugins, CLI flags, or output formatting on top of core.
 - Wrapper/caller code owns CI policy decisions (for example PR skip and auto dry-run behavior).
 - Wrapper/caller code owns git process environment hardening (for example `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, `GIT_ASKPASS`, and `GIT_TERMINAL_PROMPT`).
+- Composed callers publishing from CI should set those Git environment variables before invoking core.
 
 ## Plugin loading security model
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ const env = process.env;
 const envCi = resolveEnvCi({ cwd, env });
 const logger = getLogger({ stdout: process.stdout, stderr: process.stderr });
 
+Object.assign(env, {
+  GIT_AUTHOR_NAME: "semantic-release-bot",
+  GIT_AUTHOR_EMAIL: "semantic-release-bot@example.com",
+  GIT_COMMITTER_NAME: "semantic-release-bot",
+  GIT_COMMITTER_EMAIL: "semantic-release-bot@example.com",
+  ...env,
+  GIT_ASKPASS: "echo",
+  GIT_TERMINAL_PROMPT: 0,
+});
+
 const context = {
   cwd,
   env,

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ npm install @semantic-release/core
 
 The package exports four public entry points:
 
-- `default`: run a release with an explicit execution `context`, `plugins` input, optional `onInit` callback, and optional terminal `formatOutput` formatter.
-- `resolveConfig(context, runtimeOptions?, configOptions?)`: resolve configuration and, when requested, build the plugin pipeline.
-- `getLogger({ stdout, stderr })`: create the logger used by semantic-release.
-- `resolveEnvCi({ env?, cwd? })`: resolve CI metadata for the current environment.
+- [`default`](#default): run a release with an explicit execution `context`, `plugins` input, optional `onInit` callback, and optional terminal `formatOutput` formatter.
+- [`resolveConfig(context, runtimeOptions?, configOptions?)`](#resolveconfigcontext-runtimeoptions-configoptions): resolve configuration and, when requested, build the plugin pipeline.
+- [`getLogger({ stdout, stderr })`](#getlogger-stdout-stderr-): create the logger used by semantic-release.
+- [`resolveEnvCi({ env?, cwd? })`](#resolveenvci-env-cwd-): resolve CI metadata for the current environment.
 
 ### `default`
 


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the responsibilities of composed callers (such as wrapper packages or direct invocations) regarding Git environment configuration in CI environments. It highlights that `@semantic-release/core` does not set Git defaults for composed callers, and provides explicit guidance and code examples to prevent common CI failures related to Git author identity and credential prompts.

**Documentation improvements for CI and Git environment configuration:**

* Added a clear explanation that composed callers must configure the Git process environment (e.g., `GIT_AUTHOR_NAME`, `GIT_COMMITTER_NAME`, `GIT_ASKPASS`, `GIT_TERMINAL_PROMPT`) before invoking `@semantic-release/core`, as core does not inject these defaults for them. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R178) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216-R217)
* Provided a typical CI setup code example showing how to set the necessary Git environment variables to avoid failures during publishing in non-interactive environments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R178) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R290-R299)
* Updated documentation to emphasize that wrapper/caller code owns Git process environment hardening and should set these variables before invoking core.