### PR TITLE
feat: default Git environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const result = await semanticRelease({
 });
 ```
 
-If you compose `@semantic-release/core` for a real CI publishing workflow, you must configure the Git process environment before calling core. This applies to any composed caller, including both config-driven and direct composition. `@semantic-release/core` does not inject wrapper-level Git defaults for composed callers.
+If you compose `@semantic-release/core` for a real CI publishing workflow, core now applies default Git process environment values when they are missing.
 
 Typical CI setup:
 
@@ -174,7 +174,7 @@ Object.assign(env, {
 });
 ```
 
-Without this, publishing runs that need to create Git tags, notes, or release commits can fail when Git requires author identity or tries to prompt for credentials in a non-interactive environment.
+These values remain caller-overridable. Any values already present on `env` are preserved.
 
 ### 2. Direct composition
 
@@ -213,7 +213,7 @@ const result = await semanticRelease({
 });
 ```
 
-As with config-driven composition, direct-composition callers publishing from CI are responsible for configuring the Git process environment before invoking core.
+As with config-driven composition, direct-composition callers can still provide explicit Git process environment values before invoking core to override defaults.
 
 In the direct-composition path, the plugin list passed to core is the plugin source. `options.plugins` from config or shareable-config `extends` is not used as a fallback source for plugin loading.
 
@@ -260,8 +260,8 @@ Examples:
 - Core expects callers to provide plugins explicitly.
 - Wrapper packages can layer default plugins, CLI flags, or output formatting on top of core.
 - Wrapper/caller code owns CI policy decisions (for example PR skip and auto dry-run behavior).
-- Wrapper/caller code owns git process environment hardening (for example `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, `GIT_ASKPASS`, and `GIT_TERMINAL_PROMPT`).
-- Composed callers publishing from CI should set those Git environment variables before invoking core.
+- Core applies default git process environment hardening (for example `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, `GIT_ASKPASS`, and `GIT_TERMINAL_PROMPT`) when values are missing.
+- Wrapper/caller code can override any of those defaults by providing explicit values on `context.env`.
 
 ## Plugin loading security model
 
@@ -287,12 +287,12 @@ const env = process.env;
 const envCi = resolveEnvCi({ cwd, env });
 const logger = getLogger({ stdout: process.stdout, stderr: process.stderr });
 
+// Optional: override defaults applied by core.
 Object.assign(env, {
   GIT_AUTHOR_NAME: "semantic-release-bot",
   GIT_AUTHOR_EMAIL: "semantic-release-bot@example.com",
   GIT_COMMITTER_NAME: "semantic-release-bot",
   GIT_COMMITTER_EMAIL: "semantic-release-bot@example.com",
-  ...env,
   GIT_ASKPASS: "echo",
   GIT_TERMINAL_PROMPT: 0,
 });

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import getBranches from "./lib/branches/index.js";
 import { addNote, getGitHead, getTagHead, isBranchUpToDate, push, pushNotes, tag, verifyAuth } from "./lib/git.js";
 import getError from "./lib/get-error.js";
 import { normalizePluginsInput } from "./lib/plugins/utils.js";
+import { COMMIT_EMAIL, COMMIT_NAME } from "./lib/definitions/constants.js";
 
 export { default as resolveConfig } from "./lib/resolve-config.js";
 export { default as getLogger } from "./lib/get-logger.js";
@@ -252,6 +253,24 @@ function validateContextContract(context) {
 }
 
 /**
+ * Apply default Git environment variables to the provided env object, if they are not already set. This ensures that Git commands run with the expected author and committer information, and that prompts for credentials are suppressed in CI environments.
+ */
+function applyGitEnvDefaults(env) {
+  if (!env) {
+    return;
+  }
+
+  Object.assign(env, {
+    GIT_AUTHOR_NAME: env.GIT_AUTHOR_NAME ?? COMMIT_NAME,
+    GIT_AUTHOR_EMAIL: env.GIT_AUTHOR_EMAIL ?? COMMIT_EMAIL,
+    GIT_COMMITTER_NAME: env.GIT_COMMITTER_NAME ?? COMMIT_NAME,
+    GIT_COMMITTER_EMAIL: env.GIT_COMMITTER_EMAIL ?? COMMIT_EMAIL,
+    GIT_ASKPASS: env.GIT_ASKPASS ?? "echo",
+    GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT ?? 0,
+  });
+}
+
+/**
  * Run semantic-release with the provided context and plugins, and handle errors in a consistent way, with semantic-release errors first and their details if available, then other errors.
  */
 export default async ({ context, plugins, onInit, formatOutput = defaultFormatOutput }) => {
@@ -260,6 +279,7 @@ export default async ({ context, plugins, onInit, formatOutput = defaultFormatOu
   }
 
   validateContextContract(context);
+  applyGitEnvDefaults(context.env);
 
   if (!plugins) {
     throw new TypeError("core plugins input must be provided by the caller");

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -4,6 +4,7 @@ import envCi from "env-ci";
 import semanticRelease from "../index.js";
 import resolveConfig from "../lib/resolve-config.js";
 import getLogger from "../lib/get-logger.js";
+import { COMMIT_EMAIL, COMMIT_NAME } from "../lib/definitions/constants.js";
 import { createCiEnv, gitCommits, gitHead, gitRepo, gitTagHead } from "./helpers/git.js";
 
 async function getCoreExecutionInputs(runtimeOptions, { cwd, env, stdout = process.stdout, stderr = process.stderr }) {
@@ -265,6 +266,72 @@ test.serial("core gives precedence to direct plugins over context.options.plugin
 
   t.truthy(result);
   t.is(result.nextRelease.notes, "Notes from direct plugins");
+});
+
+test.serial("core applies default git env values when caller does not set them", async (t) => {
+  const { cwd } = await gitRepo(true);
+
+  await gitCommits(["fix: patch release"], { cwd });
+
+  const env = createCiEnv("master");
+
+  await executeCore(
+    {
+      branches: ["master"],
+      dryRun: true,
+      plugins: [
+        {
+          analyzeCommits: async () => "patch",
+          generateNotes: async () => "Release notes",
+        },
+      ],
+    },
+    { cwd, env }
+  );
+
+  t.is(env.GIT_AUTHOR_NAME, COMMIT_NAME);
+  t.is(env.GIT_AUTHOR_EMAIL, COMMIT_EMAIL);
+  t.is(env.GIT_COMMITTER_NAME, COMMIT_NAME);
+  t.is(env.GIT_COMMITTER_EMAIL, COMMIT_EMAIL);
+  t.is(env.GIT_ASKPASS, "echo");
+  t.is(env.GIT_TERMINAL_PROMPT, 0);
+});
+
+test.serial("core preserves caller-provided git env values", async (t) => {
+  const { cwd } = await gitRepo(true);
+
+  await gitCommits(["fix: patch release"], { cwd });
+
+  const env = {
+    ...createCiEnv("master"),
+    GIT_AUTHOR_NAME: "custom-author",
+    GIT_AUTHOR_EMAIL: "custom-author@example.com",
+    GIT_COMMITTER_NAME: "custom-committer",
+    GIT_COMMITTER_EMAIL: "custom-committer@example.com",
+    GIT_ASKPASS: "custom-askpass",
+    GIT_TERMINAL_PROMPT: "1",
+  };
+
+  await executeCore(
+    {
+      branches: ["master"],
+      dryRun: true,
+      plugins: [
+        {
+          analyzeCommits: async () => "patch",
+          generateNotes: async () => "Release notes",
+        },
+      ],
+    },
+    { cwd, env }
+  );
+
+  t.is(env.GIT_AUTHOR_NAME, "custom-author");
+  t.is(env.GIT_AUTHOR_EMAIL, "custom-author@example.com");
+  t.is(env.GIT_COMMITTER_NAME, "custom-committer");
+  t.is(env.GIT_COMMITTER_EMAIL, "custom-committer@example.com");
+  t.is(env.GIT_ASKPASS, "custom-askpass");
+  t.is(env.GIT_TERMINAL_PROMPT, "1");
 });
 
 test.serial("core throws when plugins input is omitted", async (t) => {


### PR DESCRIPTION
This pull request updates the default behavior of `@semantic-release/core` to automatically apply default Git environment variables in CI publishing workflows, unless they are explicitly set by the caller. This change reduces the need for wrapper code to manually set these variables, while still allowing overrides. The documentation and tests have been updated to reflect and verify this new behavior.

The most important changes include:

**Core functionality improvements:**

* Added a new `applyGitEnvDefaults` function in `index.js` that sets default Git environment variables (such as `GIT_AUTHOR_NAME`, `GIT_COMMITTER_NAME`, `GIT_ASKPASS`, and `GIT_TERMINAL_PROMPT`) if they are not already present on the environment object. This function is now called automatically in the core execution path. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R255-R272) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R282)
* Updated imports to include `COMMIT_NAME` and `COMMIT_EMAIL` constants for use in setting these defaults. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R17) [[2]](diffhunk://#diff-6bb01a9664f0d2819bc4e2290b685dddc6dfb10fd786e7fa30933ae5ec57212bR7)

**Documentation updates:**

* Updated the `README.md` to clarify that core now applies default Git environment values when missing, and that callers can override these defaults. Several sections were revised to reflect the new behavior and remove the requirement for callers to always set these variables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L161-R161) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R177) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L216-R216) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L263-R264) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R290-L295)

**Testing improvements:**

* Added integration tests to verify that the core applies default Git environment variables when they are not set by the caller, and that caller-provided values are preserved and not overwritten.

These changes make it easier and safer to compose `@semantic-release/core` in CI environments by ensuring that Git commands run with appropriate defaults, while still allowing full customization when needed.