### PR TITLE
docs: include existing environment variables in Git configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Object.assign(env, {
   GIT_AUTHOR_EMAIL: "semantic-release-bot@example.com",
   GIT_COMMITTER_NAME: "semantic-release-bot",
   GIT_COMMITTER_EMAIL: "semantic-release-bot@example.com",
+  ...env,
   GIT_ASKPASS: "echo",
   GIT_TERMINAL_PROMPT: 0,
 });


### PR DESCRIPTION
This pull request makes a minor update to the environment variable assignment in the `README.md` documentation. The change ensures that any existing properties in the `env` object are preserved and merged with the explicitly set variables.

* Added the spread operator (`...env`) to the `Object.assign` call, allowing existing environment variables to be included alongside the specified ones in the example.