### PR TITLE
docs: clarify git process environment defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,13 @@ Examples:
 
 ## Git process environment defaults
 
-When you compose `@semantic-release/core` for a real CI publishing workflow, the caller or wrapper should set the Git process environment values it wants to use in CI. If those values are missing, core applies its defaults.
+The Git process environment is what core and git use to make automated releases non-interactive and to attribute commits and tags correctly in CI.
 
-Typical CI setup:
+Set these values before building the release `context` so `context.env` already includes them.
+
+The example below shows the Git process environment values a caller or wrapper can set for CI.
+
+Typical caller-provided CI setup:
 
 ```js
 Object.assign(env, {
@@ -297,6 +301,8 @@ Object.assign(env, {
   GIT_TERMINAL_PROMPT: 0,
 });
 ```
+
+For each of these value that you do not set, core applies its own defaults.
 
 ## Dependency and ownership model
 

--- a/README.md
+++ b/README.md
@@ -159,24 +159,6 @@ const result = await semanticRelease({
 });
 ```
 
-If you compose `@semantic-release/core` for a real CI publishing workflow, core now applies default Git process environment values when they are missing.
-
-Typical CI setup:
-
-```js
-Object.assign(env, {
-  GIT_AUTHOR_NAME: "semantic-release-bot",
-  GIT_AUTHOR_EMAIL: "semantic-release-bot@example.com",
-  GIT_COMMITTER_NAME: "semantic-release-bot",
-  GIT_COMMITTER_EMAIL: "semantic-release-bot@example.com",
-  ...env,
-  GIT_ASKPASS: "echo",
-  GIT_TERMINAL_PROMPT: 0,
-});
-```
-
-These values remain caller-overridable. Any values already present on `env` are preserved.
-
 ### 2. Direct composition
 
 Pass an explicit plugin list or plugin pipeline directly to core when you want the plugin source to be authoritative in your code.
@@ -261,8 +243,6 @@ await semanticRelease({
 });
 ```
 
-As with config-driven composition, direct-composition callers can still provide explicit Git process environment values before invoking core to override defaults.
-
 In the direct-composition path, any plugin list passed to core is the plugin source, whether it comes directly from caller code or from wrapper code that first reads `options.plugins`. `options.plugins` from config or shareable-config `extends` is not used as a fallback source for plugin loading once the caller passes `plugins` explicitly.
 
 ## Core contract
@@ -300,6 +280,24 @@ Examples:
 - `options.analyzeCommits` is a plugin spec -> no fallback injection.
 - `options.analyzeCommits` is an options-only plain object or is absent -> commit-analyzer is injected and the options are merged into it.
 
+## Git process environment defaults
+
+When you compose `@semantic-release/core` for a real CI publishing workflow, the caller or wrapper should set the Git process environment values it wants to use in CI. If those values are missing, core applies its defaults.
+
+Typical CI setup:
+
+```js
+Object.assign(env, {
+  GIT_AUTHOR_NAME: "semantic-release-bot",
+  GIT_AUTHOR_EMAIL: "semantic-release-bot@semantic-release.org",
+  GIT_COMMITTER_NAME: "semantic-release-bot",
+  GIT_COMMITTER_EMAIL: "semantic-release-bot@semantic-release.org",
+  ...env,
+  GIT_ASKPASS: "echo",
+  GIT_TERMINAL_PROMPT: 0,
+});
+```
+
 ## Dependency and ownership model
 
 `@semantic-release/core` does not own CLI parsing or wrapper defaults.
@@ -308,7 +306,7 @@ Examples:
 - Core expects callers to provide plugins explicitly.
 - Wrapper packages can layer default plugins, CLI flags, or output formatting on top of core.
 - Wrapper/caller code owns CI policy decisions (for example PR skip and auto dry-run behavior).
-- Core applies default git process environment hardening (for example `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, `GIT_ASKPASS`, and `GIT_TERMINAL_PROMPT`) when values are missing.
+- Core applies default git process environment hardening when values are missing; see [Git process environment defaults](#git-process-environment-defaults).
 - Wrapper/caller code can override any of those defaults by providing explicit values on `context.env`.
 
 ## Plugin loading security model


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to clarify how Git process environment defaults are handled in CI workflows when using `@semantic-release/core`. The changes reorganize and expand the explanation of environment variable defaults, making it clearer for users how and when to set or override these values.

Key documentation improvements:

**Clarification and reorganization of Git environment variable defaults:**
- Moved and expanded the explanation of Git process environment defaults to a dedicated section, providing a clearer example of how callers should set these variables for CI environments.
- Updated the example email addresses in the environment variable setup to use the official `semantic-release.org` domain for clarity and consistency.
- Clarified that core applies its own defaults for any Git environment values not set by the caller, and that these remain overridable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R283-R306) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L311-R315)

**Streamlining and removal of redundant documentation:**
- Removed redundant and outdated explanations regarding environment variable handling from earlier sections to avoid confusion and duplication. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L162-L179) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L264-L265)
- Updated references to environment variable hardening in the dependency and ownership model section to point to the new, dedicated section for easier navigation.