### PR TITLE
refactor: first prerelease constant naming

### DIFF
--- a/lib/definitions/constants.js
+++ b/lib/definitions/constants.js
@@ -2,7 +2,7 @@ export const RELEASE_TYPE = ["patch", "minor", "major"];
 
 export const FIRST_RELEASE = "1.0.0";
 
-export const FIRSTPRERELEASE = "1";
+export const FIRST_PRERELEASE = "1";
 
 export const COMMIT_NAME = "semantic-release-bot";
 

--- a/lib/get-next-version.js
+++ b/lib/get-next-version.js
@@ -27,7 +27,8 @@ export default ({ branch, nextRelease: { type, channel }, lastRelease, logger })
 
     logger.log("The next release version is %s", version);
   } else {
-    version = branch.type === "prerelease" ? `${FIRST_RELEASE}-${branch.prerelease}.${FIRST_PRERELEASE}` : FIRST_RELEASE;
+    version =
+      branch.type === "prerelease" ? `${FIRST_RELEASE}-${branch.prerelease}.${FIRST_PRERELEASE}` : FIRST_RELEASE;
     logger.log(`There is no previous release, the next release version is ${version}`);
   }
 

--- a/lib/get-next-version.js
+++ b/lib/get-next-version.js
@@ -1,5 +1,5 @@
 import semver from "semver";
-import { FIRST_RELEASE, FIRSTPRERELEASE } from "./definitions/constants.js";
+import { FIRST_RELEASE, FIRST_PRERELEASE } from "./definitions/constants.js";
 import { getLatestVersion, highest, isSameChannel, tagsToVersions } from "./utils.js";
 
 export default ({ branch, nextRelease: { type, channel }, lastRelease, logger }) => {
@@ -16,10 +16,10 @@ export default ({ branch, nextRelease: { type, channel }, lastRelease, logger })
           semver.inc(lastRelease.version, "prerelease"),
           `${semver.inc(getLatestVersion(tagsToVersions(branch.tags), { withPrerelease: true }), type)}-${
             branch.prerelease
-          }.${FIRSTPRERELEASE}`
+          }.${FIRST_PRERELEASE}`
         );
       } else {
-        version = `${semver.inc(`${major}.${minor}.${patch}`, type)}-${branch.prerelease}.${FIRSTPRERELEASE}`;
+        version = `${semver.inc(`${major}.${minor}.${patch}`, type)}-${branch.prerelease}.${FIRST_PRERELEASE}`;
       }
     } else {
       version = semver.inc(lastRelease.version, type);
@@ -27,7 +27,7 @@ export default ({ branch, nextRelease: { type, channel }, lastRelease, logger })
 
     logger.log("The next release version is %s", version);
   } else {
-    version = branch.type === "prerelease" ? `${FIRST_RELEASE}-${branch.prerelease}.${FIRSTPRERELEASE}` : FIRST_RELEASE;
+    version = branch.type === "prerelease" ? `${FIRST_RELEASE}-${branch.prerelease}.${FIRST_PRERELEASE}` : FIRST_RELEASE;
     logger.log(`There is no previous release, the next release version is ${version}`);
   }
 


### PR DESCRIPTION
This pull request makes a small but important change to improve code clarity and consistency by renaming a constant throughout the codebase. The constant `FIRSTPRERELEASE` has been renamed to `FIRST_PRERELEASE` to follow a more conventional naming style for constants.

- Renamed constant:
  * Renamed `FIRSTPRERELEASE` to `FIRST_PRERELEASE` in `lib/definitions/constants.js` and updated all references in `lib/get-next-version.js` to use the new name. [[1]](diffhunk://#diff-5ca2332ebe61b12a91cf9b8eb3c00a7b22667699fa09d91c931399c14d197d41L5-R5) [[2]](diffhunk://#diff-a2ae8c9d8805b6b929f24addf80399086a982b73471bc9c95596e8249c54f430L2-R2) [[3]](diffhunk://#diff-a2ae8c9d8805b6b929f24addf80399086a982b73471bc9c95596e8249c54f430L19-R30)